### PR TITLE
Accident_Index is not identical to Accident_Index

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -159,7 +159,7 @@ check_input_file = function(filename = NULL,
 # read_ve_ca(path)
 read_ve_ca = function(path) {
   h = utils::read.csv(path, nrows = 1)
-  if(identical(names(h)[1], "Accident_Index")) {
+  if(grepl("Accident_Index", names(h)[1])) {
     readr::read_csv(path, col_types = readr::cols(
       .default = readr::col_integer(),
       Accident_Index = readr::col_character()


### PR DESCRIPTION
`identical` function in R behaves differently on MacOS, Linux vs Windows for a particular case in `stats19` strings that can be reproduced.

Links & notes: 
https://www.r-project.org/bugs.html

crashes 2017 file first column name here results in 
http://data.dft.gov.uk.s3.amazonaws.com/road-accidents-safety-data/dftRoadSafetyData_Accidents_2017.zip