### PR TITLE
Add silent parameter to get_stats19 

### DIFF
--- a/R/dl.R
+++ b/R/dl.R
@@ -19,6 +19,8 @@
 #' Or any variation of to search the file names with such as "acc" or "accid".
 #' @param data_dir Parent directory for all downloaded files. Defaults to `tempdir()`.
 #' @param ask Should you be asked whether or not to download the files? `TRUE` by default.
+#' @param silent Boolean. If `FALSE` (default value), display useful progress
+#'   messages on the screen.
 #'
 #' @export
 #' @examples
@@ -34,7 +36,8 @@ dl_stats19 = function(year = NULL,
                       type = NULL,
                       data_dir = get_data_directory(),
                       file_name = NULL,
-                      ask = FALSE
+                      ask = FALSE,
+                      silent = FALSE
                       ) {
   if(!is.null (year)) {
     year = check_year(year)
@@ -47,7 +50,9 @@ dl_stats19 = function(year = NULL,
       if(interactive()) {
         fnames = select_file(fnames)
       } else {
-        message("More than one file found, selecting the first.")
+        if (isFALSE(silent)){
+          message("More than one file found, selecting the first.")
+        }
         fnames = fnames[1]
       }
     }
@@ -59,8 +64,11 @@ dl_stats19 = function(year = NULL,
     zip_url = get_url(file_name = file_name)
   }
 
-  message("Files identified: ", paste0(fnames, "\n"))
-  message(paste0("   ", zip_url, collapse = "\n"))
+  if (isFALSE(silent)) {
+    message("Files identified: ", paste0(fnames, "\n"))
+    message(paste0("   ", zip_url, collapse = "\n"))
+  }
+
   if (!dir.exists(data_dir)) {
     dir.create(data_dir, recursive = TRUE)
   }
@@ -74,7 +82,9 @@ dl_stats19 = function(year = NULL,
   }
     data_already_exists = file.exists(destfile)
     if(data_already_exists) {
-      message("Data already exists in data_dir, not downloading")
+      if (isFALSE(silent)) {
+        message("Data already exists in data_dir, not downloading")
+      }
     } else {
       if(interactive() & !many_found) {
         if(ask) {
@@ -86,14 +96,18 @@ dl_stats19 = function(year = NULL,
           stop("Stopping as requested", call. = FALSE)
         }
       }
-      message("Attempt downloading from: ")
+      if (isFALSE(silent)) {
+        message("Attempt downloading from: ")
+      }
       utils::download.file(zip_url, destfile = destfile)
     }
     if(is_zip_file) {
       f = file.path(destfile, utils::unzip(destfile, list = TRUE)$Name)
       utils::unzip(destfile, exdir = file.path(data_dir, exdir))
-      message("Data saved at ", sub(".zip", "",f))
-    } else {
+      if (isFALSE(silent)) {
+        message("Data saved at ", sub(".zip", "",f))
+      }
+    } else if (isFALSE(silent)) {
       message("Data saved at ", destfile)
     }
 }

--- a/R/get.R
+++ b/R/get.R
@@ -78,6 +78,7 @@ get_stats19 = function(year = NULL,
                       file_name = NULL,
                       format = TRUE,
                       ask = FALSE,
+                      silent = FALSE,
                       output_format = "tibble",
                       ...) {
   if(!exists("type")) {
@@ -101,7 +102,8 @@ get_stats19 = function(year = NULL,
              type = type,
              data_dir = data_dir,
              file_name = file_name,
-             ask = ask)
+             ask = ask,
+             silent = silent)
   read_in = NULL
   # read in
   if(grepl(type, "vehicles",  ignore.case = TRUE)){
@@ -118,7 +120,8 @@ get_stats19 = function(year = NULL,
     read_in = read_accidents(
       year = year,
       data_dir = data_dir,
-      format = format)
+      format = format,
+      silent = silent)
   }
 
   # transform read_in into the desired format

--- a/R/read.R
+++ b/R/read.R
@@ -10,6 +10,8 @@
 #' @param data_dir Where sets of downloaded data would be found.
 #' @param year Single year for which data are to be read
 #' @param format Switch to return raw read from file, default is `TRUE`.
+#' @param silent Boolean. If `FALSE` (default value), display useful progress
+#'   messages on the screen.
 #'
 #' @export
 #' @examples
@@ -23,15 +25,18 @@
 read_accidents = function(year = NULL,
                           filename = "",
                           data_dir = get_data_directory(),
-                          format = TRUE) {
+                          format = TRUE,
+                          silent = FALSE) {
   path = check_input_file(
     filename = filename,
     type = "accidents",
     data_dir = data_dir,
     year = year
   )
-  message("Reading in: ")
-  message(path)
+  if (isFALSE(silent)) {
+    message("Reading in: ")
+    message(path)
+  }
   # read the data in
   suppressWarnings({
     ac = readr::read_csv(

--- a/man/dl_stats19.Rd
+++ b/man/dl_stats19.Rd
@@ -9,7 +9,8 @@ dl_stats19(
   type = NULL,
   data_dir = get_data_directory(),
   file_name = NULL,
-  ask = FALSE
+  ask = FALSE,
+  silent = FALSE
 )
 }
 \arguments{
@@ -23,6 +24,9 @@ Or any variation of to search the file names with such as "acc" or "accid".}
 \item{file_name}{The file name (DfT named) to download.}
 
 \item{ask}{Should you be asked whether or not to download the files? \code{TRUE} by default.}
+
+\item{silent}{Boolean. If \code{FALSE} (default value), display useful progress
+messages on the screen.}
 }
 \description{
 Download STATS19 data for a year or range of two years.

--- a/man/get_stats19.Rd
+++ b/man/get_stats19.Rd
@@ -11,6 +11,7 @@ get_stats19(
   file_name = NULL,
   format = TRUE,
   ask = FALSE,
+  silent = FALSE,
   output_format = "tibble",
   ...
 )
@@ -28,6 +29,9 @@ Or any variation of to search the file names with such as "acc" or "accid".}
 \item{format}{Switch to return raw read from file, default is \code{TRUE}.}
 
 \item{ask}{Should you be asked whether or not to download the files? \code{TRUE} by default.}
+
+\item{silent}{Boolean. If \code{FALSE} (default value), display useful progress
+messages on the screen.}
 
 \item{output_format}{The default value is "tibble". Other possible values are
 \code{\link[sf]{st_as_sf}} object or \code{\link[spatstat]{ppp}} object.

--- a/man/read_accidents.Rd
+++ b/man/read_accidents.Rd
@@ -8,7 +8,8 @@ read_accidents(
   year = NULL,
   filename = "",
   data_dir = get_data_directory(),
-  format = TRUE
+  format = TRUE,
+  silent = FALSE
 )
 }
 \arguments{
@@ -20,6 +21,9 @@ years determine whether there is a target to read, otherwise disk scan would be 
 \item{data_dir}{Where sets of downloaded data would be found.}
 
 \item{format}{Switch to return raw read from file, default is \code{TRUE}.}
+
+\item{silent}{Boolean. If \code{FALSE} (default value), display useful progress
+messages on the screen.}
 }
 \description{
 Read in STATS19 road safety data from .csv files downloaded.


### PR DESCRIPTION
As we discussed in #140, I added a silent parameter to get_stats19. For example: 

``` r
res <- stats19::get_stats19(2018)
#> Files identified: dftRoadSafetyData_Accidents_2018.csv
#>    http://data.dft.gov.uk.s3.amazonaws.com/road-accidents-safety-data/dftRoadSafetyData_Accidents_2018.csv
#> Attempt downloading from:
#> Data saved at /tmp/Rtmp9K14gT/dftRoadSafetyData_Accidents_2018.csv
#> Reading in:
#> /tmp/Rtmp9K14gT/dftRoadSafetyData_Accidents_2018.csv
#> date and time columns present, creating formatted datetime column
```

<sup>Created on 2020-01-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

and

``` r
res <- stats19::get_stats19(2018, silent = TRUE)
#> date and time columns present, creating formatted datetime column
```

<sup>Created on 2020-01-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

I choose not to silent in any case the new date/time message but it's really easy to add that.  
