### PR TITLE
Add check for overlapping files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Suggests:
     spatstat,
     osmdata
 VignetteBuilder: knitr
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 Language: en-US
 X-schema.org-keywords: stats19, road-safety, transport, car-crashes, ropensci, data

--- a/R/get.R
+++ b/R/get.R
@@ -198,8 +198,7 @@ get_stats19 = function(year = NULL,
 }
 
 # This function is used to check if there is an overlapping of files with
-# multiple years. The matching between the years and the files work as follows:
-# lapply(1979:2018, stats19::find_file_name)
+# multiple years. The matching between the years and the files works as follows:
 # 1979 ... 2004 ---> 1979 - 2004
 # 2005 ... 2008 ---> 2005 - 2014
 # 2009          ---> 2009
@@ -207,14 +206,15 @@ get_stats19 = function(year = NULL,
 # 2011          ---> 2011
 # ...
 # 2018          ---> 2018
+# See lapply(1979:2018, stats19::find_file_name)
 # So if I select 2005:2014 I should download only 2005 while if I select
 # 2009:2014 I should download all separate years.
 # See also https://github.com/ropensci/stats19/issues/168
 check_overlapping_files = function(year) {
   year[year %in% 1979:2004] = 1979
   if (any(year %in% 2005:2008)) {
-    # The year 2005 contains data since 2014 so I also exclude the years from
-    # 2005 to 2015
+    # The year 2005 contains data up to 2014 so I also exclude the years from
+    # 2005 to 2014
     year[year %in% 2005:2014] = 2005
   }
   year = unique(year)

--- a/R/get.R
+++ b/R/get.R
@@ -126,6 +126,10 @@ get_stats19 = function(year = NULL,
     output_format = "tibble"
   }
 
+  if(!is.null (year)) {
+    year = check_year(year)
+  }
+
   if(is.vector(year) && length(year) > 1) {
     year = check_overlapping_files(year)
     all  = list()

--- a/R/get.R
+++ b/R/get.R
@@ -131,7 +131,6 @@ get_stats19 = function(year = NULL,
   }
 
   if(is.vector(year) && length(year) > 1) {
-    year = check_overlapping_files(year)
     all  = list()
     i = 1
     for (aYear in year) {
@@ -199,29 +198,5 @@ get_stats19 = function(year = NULL,
   }
 
   read_in
-}
-
-# This function is used to check if there is an overlapping of files with
-# multiple years. The matching between the years and the files works as follows:
-# 1979 ... 2004 ---> 1979 - 2004
-# 2005 ... 2008 ---> 2005 - 2014
-# 2009          ---> 2009
-# 2010          ---> 2010
-# 2011          ---> 2011
-# ...
-# 2018          ---> 2018
-# See lapply(1979:2018, stats19::find_file_name)
-# So if I select 2005:2014 I should download only 2005 while if I select
-# 2009:2014 I should download all separate years.
-# See also https://github.com/ropensci/stats19/issues/168
-check_overlapping_files = function(year) {
-  year[year %in% 1979:2004] = 1979
-  if (any(year %in% 2005:2008)) {
-    # The year 2005 contains data up to 2014 so I also exclude the years from
-    # 2005 to 2014
-    year[year %in% 2005:2014] = 2005
-  }
-  year = unique(year)
-  year
 }
 

--- a/R/get.R
+++ b/R/get.R
@@ -127,6 +127,7 @@ get_stats19 = function(year = NULL,
   }
 
   if(is.vector(year) && length(year) > 1) {
+    year = check_overlapping_files(year)
     all  = list()
     i = 1
     for (aYear in year) {
@@ -196,6 +197,27 @@ get_stats19 = function(year = NULL,
   read_in
 }
 
-
-
+# This function is used to check if there is an overlapping of files with
+# multiple years. The matching between the years and the files work as follows:
+# lapply(1979:2018, stats19::find_file_name)
+# 1979 ... 2004 ---> 1979 - 2004
+# 2005 ... 2008 ---> 2005 - 2014
+# 2009          ---> 2009
+# 2010          ---> 2010
+# 2011          ---> 2011
+# ...
+# 2018          ---> 2018
+# So if I select 2005:2014 I should download only 2005 while if I select
+# 2009:2014 I should download all separate years.
+# See also https://github.com/ropensci/stats19/issues/168
+check_overlapping_files = function(year) {
+  year[year %in% 1979:2004] = 1979
+  if (any(year %in% 2005:2008)) {
+    # The year 2005 contains data since 2014 so I also exclude the years from
+    # 2005 to 2015
+    year[year %in% 2005:2014] = 2005
+  }
+  year = unique(year)
+  year
+}
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,23 +30,24 @@ get_url = function(file_name = "",
 #' # check_year(1985)
 #' @inheritParams dl_stats19
 check_year = function(year) {
-  year = as.integer(year)
+  if(!is.numeric(year)) year = as.numeric(year)
   is_year = all(year %in% 1979:(current_year() - 1))
-  if(!is_year || is.na(year) || length(year) == 0) {
+  if(!is_year || any(is.na(year)) || length(year) == 0) {
     msg = paste0("Years must be in range 1979:", current_year() - 1)
     stop(msg, call. = FALSE)
   }
   # valid year, continue
-  if(all(year %in% 1980:2003)) {
+  if(all(year %in% 1979:2004)) {
     message("Year not in range, changing to match 1979:2004 data")
     year = 1979
   }
   # we have an overlap of year 2009 to 2014 as
   # individual zip files and
   # bundled within 2005-2014
-  if(any(year %in% 2006:2008)) {
+  if(any(year %in% 2005:2008)) {
     message("Year not in range, changing to match 2005:2014 data")
-    year = 2005
+    year[year %in% 2005:2014] = 2005
+    year = unique(year)
   }
   year
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,7 +22,19 @@ get_url = function(file_name = "",
   path = file.path(domain, directory, file_name)
   path
 }
-#' check and convert year argument
+
+#' This function does two things:
+#' 1. is used to check if there is an overlapping of files with
+#' multiple years. The matching between the years and the files works as follows:
+#' 1979 ... 2004 ---> 1979 - 2004
+#' 2005 ... 2008 ---> 2005 - 2014
+#' 2009          ---> 2009
+#' 2010          ---> 2010
+#' 2011          ---> 2011
+#' ...
+#' 2018          ---> 2018
+#' 2. it also does the sanity checking of the year(s) given
+#'
 #' @examples
 #' # check_year("2018") # fails
 #' # check_year(2017)
@@ -37,9 +49,9 @@ check_year = function(year) {
     stop(msg, call. = FALSE)
   }
   # valid year, continue
-  if(all(year %in% 1979:2004)) {
+  if(any(year %in% 1979:2004)) {
     message("Year not in range, changing to match 1979:2004 data")
-    year = 1979
+    year[year %in% 1979:2004] = 1979
   }
   # we have an overlap of year 2009 to 2014 as
   # individual zip files and
@@ -47,8 +59,8 @@ check_year = function(year) {
   if(any(year %in% 2005:2008)) {
     message("Year not in range, changing to match 2005:2014 data")
     year[year %in% 2005:2014] = 2005
-    year = unique(year)
   }
+  year = unique(year)
   year
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,18 +37,18 @@ check_year = function(year) {
     stop(msg, call. = FALSE)
   }
   # valid year, continue
-  if(year %in% 1980:2003) {
+  if(all(year %in% 1980:2003)) {
     message("Year not in range, changing to match 1979:2004 data")
     year = 1979
   }
   # we have an overlap of year 2009 to 2014 as
   # individual zip files and
   # bundled within 2005-2014
-  if(year %in% 2006:2008) {
+  if(any(year %in% 2006:2008)) {
     message("Year not in range, changing to match 2005:2014 data")
     year = 2005
   }
-  as.integer(year)
+  year
 }
 
 # current_year()

--- a/R/utils.R
+++ b/R/utils.R
@@ -75,7 +75,7 @@ find_file_name = function(years = NULL, type = NULL) {
   result = unlist(stats19::file_names, use.names = FALSE)
 
   if(!is.null(years)) {
-    years = vapply(years, check_year, integer(1)) # todo: vectorise?
+    years = sapply(years, check_year)
     years_regex = paste0(years, collapse = "|")
     result = result[grep(pattern = years_regex, x = result)]
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -23,7 +23,7 @@ get_url = function(file_name = "",
   path
 }
 
-#' This function does two things:
+#' This is a private function which does two things:
 #' 1. is used to check if there is an overlapping of files with
 #' multiple years. The matching between the years and the files works as follows:
 #' 1979 ... 2004 ---> 1979 - 2004
@@ -35,12 +35,13 @@ get_url = function(file_name = "",
 #' 2018          ---> 2018
 #' 2. it also does the sanity checking of the year(s) given
 #'
+#' @param year Year(s) vector to check.
 #' @examples
-#' # check_year("2018") # fails
-#' # check_year(2017)
+#' # check_year("2018")
+#' # check_year(1979:2018)
+#' #> c(1979, 2005, 2015:2018)
 #' # check_year(2006)
 #' # check_year(1985)
-#' @inheritParams dl_stats19
 check_year = function(year) {
   if(!is.numeric(year)) year = as.numeric(year)
   is_year = all(year %in% 1979:(current_year() - 1))

--- a/man/accidents_sample.Rd
+++ b/man/accidents_sample.Rd
@@ -5,7 +5,9 @@
 \alias{accidents_sample}
 \alias{accidents_sample_raw}
 \title{Sample of stats19 data (2017 accidents)}
-\format{A data frame}
+\format{
+A data frame
+}
 \description{
 Sample of stats19 data (2017 accidents)
 }

--- a/man/casualties_sample.Rd
+++ b/man/casualties_sample.Rd
@@ -5,7 +5,9 @@
 \alias{casualties_sample}
 \alias{casualties_sample_raw}
 \title{Sample of stats19 data (2017 casualties)}
-\format{A data frame}
+\format{
+A data frame
+}
 \description{
 Sample of stats19 data (2017 casualties)
 }

--- a/man/check_year.Rd
+++ b/man/check_year.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils.R
 \name{check_year}
 \alias{check_year}
-\title{This function does two things:
+\title{This is a private function which does two things:
 \enumerate{
 \item is used to check if there is an overlapping of files with
 multiple years. The matching between the years and the files works as follows:
@@ -19,10 +19,10 @@ multiple years. The matching between the years and the files works as follows:
 check_year(year)
 }
 \arguments{
-\item{year}{Single year for which file is to be downloaded.}
+\item{year}{Year(s) vector to check.}
 }
 \description{
-This function does two things:
+This is a private function which does two things:
 \enumerate{
 \item is used to check if there is an overlapping of files with
 multiple years. The matching between the years and the files works as follows:
@@ -37,8 +37,9 @@ multiple years. The matching between the years and the files works as follows:
 }
 }
 \examples{
-# check_year("2018") # fails
-# check_year(2017)
+# check_year("2018")
+# check_year(1979:2018)
+#> c(1979, 2005, 2015:2018)
 # check_year(2006)
 # check_year(1985)
 }

--- a/man/check_year.Rd
+++ b/man/check_year.Rd
@@ -2,7 +2,19 @@
 % Please edit documentation in R/utils.R
 \name{check_year}
 \alias{check_year}
-\title{check and convert year argument}
+\title{This function does two things:
+\enumerate{
+\item is used to check if there is an overlapping of files with
+multiple years. The matching between the years and the files works as follows:
+1979 ... 2004 ---> 1979 - 2004
+2005 ... 2008 ---> 2005 - 2014
+2009          ---> 2009
+2010          ---> 2010
+2011          ---> 2011
+...
+2018          ---> 2018
+\item it also does the sanity checking of the year(s) given
+}}
 \usage{
 check_year(year)
 }
@@ -10,7 +22,19 @@ check_year(year)
 \item{year}{Single year for which file is to be downloaded.}
 }
 \description{
-check and convert year argument
+This function does two things:
+\enumerate{
+\item is used to check if there is an overlapping of files with
+multiple years. The matching between the years and the files works as follows:
+1979 ... 2004 ---> 1979 - 2004
+2005 ... 2008 ---> 2005 - 2014
+2009          ---> 2009
+2010          ---> 2010
+2011          ---> 2011
+...
+2018          ---> 2018
+\item it also does the sanity checking of the year(s) given
+}
 }
 \examples{
 # check_year("2018") # fails

--- a/man/file_names.Rd
+++ b/man/file_names.Rd
@@ -5,7 +5,9 @@
 \alias{file_names}
 \alias{file_names_old}
 \title{stats19 file names for easy access}
-\format{A named list}
+\format{
+A named list
+}
 \description{
 URL decoded file names. Currently there are 52 file names
 released by the DfT (Department for Transport) and the details include

--- a/man/police_boundaries.Rd
+++ b/man/police_boundaries.Rd
@@ -4,7 +4,9 @@
 \name{police_boundaries}
 \alias{police_boundaries}
 \title{Police force boundaries in England (2016)}
-\format{An sf data frame}
+\format{
+An sf data frame
+}
 \description{
 This dataset represents the 43 police forces in England and Wales.
 These are described on the

--- a/man/schema_original.Rd
+++ b/man/schema_original.Rd
@@ -4,7 +4,9 @@
 \name{schema_original}
 \alias{schema_original}
 \title{Schema for stats19 data (UKDS)}
-\format{A data frame}
+\format{
+A data frame
+}
 \description{
 Schema for stats19 data (UKDS)
 }

--- a/man/vehicles_sample.Rd
+++ b/man/vehicles_sample.Rd
@@ -5,7 +5,9 @@
 \alias{vehicles_sample}
 \alias{vehicles_sample_raw}
 \title{Sample of stats19 data (2017 vehicles)}
-\format{A data frame}
+\format{
+A data frame
+}
 \description{
 Sample of stats19 data (2017 vehicles)
 }

--- a/tests/testthat/test-check-year.R
+++ b/tests/testthat/test-check-year.R
@@ -1,5 +1,3 @@
-test_that("multiplication works", {
-  devtools::load_all()
-  # print(check_year(2005:2010))
+test_that("check-year works", {
   expect_equal(check_year(2005:2010), 2005)
 })

--- a/tests/testthat/test-check-year.R
+++ b/tests/testthat/test-check-year.R
@@ -2,4 +2,6 @@ test_that("check-year works", {
   expect_equal(check_year(2005:2010), 2005)
   expect_true(identical(check_year(c(2017, 2018)),
                         as.numeric(c(2017, 2018))))
+  expect_true(identical(check_year(1979:2018),
+                        as.numeric(c(1979, 2005, 2015:2018))))
 })

--- a/tests/testthat/test-check-year.R
+++ b/tests/testthat/test-check-year.R
@@ -1,3 +1,5 @@
 test_that("check-year works", {
   expect_equal(check_year(2005:2010), 2005)
+  expect_true(identical(check_year(c(2017, 2018)),
+                        as.numeric(c(2017, 2018))))
 })

--- a/tests/testthat/test-check-year.R
+++ b/tests/testthat/test-check-year.R
@@ -1,0 +1,5 @@
+test_that("multiplication works", {
+  devtools::load_all()
+  # print(check_year(2005:2010))
+  expect_equal(check_year(2005:2010), 2005)
+})


### PR DESCRIPTION
Fixes #168. These are some tests with the "new" function: 

``` r
stats19:::check_overlapping_files(1979:2018)
#> [1] 1979 2005 2015 2016 2017 2018
stats19:::check_overlapping_files(2005:2018)
#> [1] 2005 2015 2016 2017 2018
stats19:::check_overlapping_files(2009:2018)
#>  [1] 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018
stats19:::check_overlapping_files(2004:2018)
#> [1] 1979 2005 2015 2016 2017 2018
```

<sup>Created on 2020-06-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

I'm not sure if I should also add a message or a warning. 