### PR TITLE
Test that path points to a CSV file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,8 @@ Encoding: UTF-8
 LazyData: true
 Imports: 
     sf,
-    readr
+    readr,
+    tools
 Suggests: 
     curl (>= 3.2),
     dplyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# stats19 (development version)
+
+* Added a test to prevent rare failures in `get_stats19()` when `data_dir` points to the working directory.  
+
 # stats19 1.4.0
 
 * Add `get_stats19_adjustments()` function

--- a/R/utils.R
+++ b/R/utils.R
@@ -181,7 +181,9 @@ locate_one_file = function(filename = NULL,
   if(length(path) == 0) {
     stop("No files found under: ", data_dir, call. = FALSE)
   }
-  if(length(path) == 1 && file.exists(path)) {
+  # Test if path points to a single existing CSV file. See
+  # https://github.com/ropensci/stats19/issues/197 for more details.
+  if (length(path) == 1 && file.exists(path) && tools::file_ext(path) == "csv") {
     return(path)
   }
   scan1 = function(path, type) {

--- a/man/get_ULEZ.Rd
+++ b/man/get_ULEZ.Rd
@@ -14,10 +14,10 @@ Download DVLA-based vehicle data from the TfL API using VRM.
 }
 \section{Details}{
 
-This function takes a a character vector of vehicle registrations (VRMs) and returns DVLA-based vehicle data from TfL's API, included ULEZ eligibility.
+This function takes a character vector of vehicle registrations (VRMs) and returns DVLA-based vehicle data from TfL's API, included ULEZ eligibility.
 It returns a data frame of those VRMs which were successfully used with the TfL API.  Vehicles are either compliant, non-compliant or exempt.  ULEZ-exempt vehicles will not have all vehicle details returned - they will simply be marked "exempt".
 
-Be aware that the API has usage limits.  The function will therefore limit API calls to 50 per minute.
+Be aware that the API has usage limits.  The function will therefore limit API calls to below 50 per minute - this is the maximum rate before an API key is required.
 }
 
 \examples{


### PR DESCRIPTION
fix #197

Reprex: 

``` r
library(stats19)
#> Data provided under OGL v3.0. Cite the source and link to:
#> www.nationalarchives.gov.uk/doc/open-government-licence/version/3/

check_dd <- function(year, ...) {
  message("checking... ", year)
  d = get_stats19(year, data_dir = ".", ...)
  return(nrow(d) > 0)
}

check_dd(2017, silent = TRUE)
#> checking... 2017
#> date and time columns present, creating formatted datetime column
#> [1] TRUE
check_dd(2018, silent = TRUE)
#> checking... 2018
#> date and time columns present, creating formatted datetime column
#> [1] TRUE
check_dd(2019, silent = TRUE)
#> checking... 2019
#> date and time columns present, creating formatted datetime column
#> [1] TRUE
```

<sup>Created on 2021-03-25 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>
