### PR TITLE
Two small updates

### DIFF
--- a/R/mot.R
+++ b/R/mot.R
@@ -134,27 +134,27 @@ get_MOT = function(vrm, apikey) {
   try(result.df$manufactureYear <- as.numeric(result.df$manufactureYear), silent = TRUE)
 
   # Convert all units to miles
-  result.df$latestOdometer[is.na(result.df$latestOdometerUnit)] = NA
-  result.df$prevOdometer[is.na(result.df$prevOdometerUnit)] = NA
-  result.df$latestOdometer[result.df$latestOdometerUnit == "km" & !is.na(result.df$latestOdometer)] = result.df$latestOdometer[result.df$latestOdometerUnit == "km" & !is.na(result.df$latestOdometer)] * 0.621371
-  result.df$prevOdometer[result.df$prevOdometerUnit == "km" & !is.na(result.df$prevOdometer)] = result.df$prevOdometer[result.df$prevOdometerUnit == "km" & !is.na(result.df$prevOdometer)] * 0.621371
-  result.df$latestOdometerUnit = NULL
-  result.df$prevOdometerUnit = NULL
+  try(result.df$latestOdometer[is.na(result.df$latestOdometerUnit)] <- NA, silent = TRUE)
+  try(result.df$prevOdometer[is.na(result.df$prevOdometerUnit)] <- NA, silent = TRUE)
+  try(result.df$latestOdometer[result.df$latestOdometerUnit == "km" & !is.na(result.df$latestOdometer)] <- result.df$latestOdometer[result.df$latestOdometerUnit == "km" & !is.na(result.df$latestOdometer)] * 0.621371, silent = TRUE)
+  try(result.df$prevOdometer[result.df$prevOdometerUnit == "km" & !is.na(result.df$prevOdometer)] <- result.df$prevOdometer[result.df$prevOdometerUnit == "km" & !is.na(result.df$prevOdometer)] * 0.621371, silent = TRUE)
+  try(result.df$latestOdometerUnit <- NULL, silent = TRUE)
+  try(result.df$prevOdometerUnit <- NULL, silent = TRUE)
 
   # Derive miles per year estimate
-  result.df$test_diff = as.Date(result.df$latestOdometerDate) - as.Date(result.df$prevOdometerDate)
-  result.df$test_diff[is.na(result.df$prevOdometerDate)] = as.Date(result.df$latestOdometerDate[is.na(result.df$prevOdometerDate)]) - as.Date(result.df$registrationDate[is.na(result.df$prevOdometerDate)])
-  result.df$dist_diff = result.df$latestOdometer - result.df$prevOdometer
-  result.df$dist_diff[is.na(result.df$prevOdometerDate)] = result.df$latestOdometer[is.na(result.df$prevOdometerDate)] - 0
-  result.df$latestAnnualEstMileage = (result.df$dist_diff/as.numeric(result.df$test_diff))*365.24
-  result.df$EstimatePeriod = result.df$test_diff/365.24
-  result.df$EstimatePeriod[is.na(result.df$latestAnnualEstMileage)] = NA
+  try(result.df$test_diff <- as.Date(result.df$latestOdometerDate) - as.Date(result.df$prevOdometerDate), silent = TRUE)
+  try(result.df$test_diff[is.na(result.df$prevOdometerDate)] <- as.Date(result.df$latestOdometerDate[is.na(result.df$prevOdometerDate)]) - as.Date(result.df$registrationDate[is.na(result.df$prevOdometerDate)]), silent = TRUE)
+  try(result.df$dist_diff <- result.df$latestOdometer - result.df$prevOdometer, silent = TRUE)
+  try(result.df$dist_diff[is.na(result.df$prevOdometerDate)] <- result.df$latestOdometer[is.na(result.df$prevOdometerDate)] - 0, silent = TRUE)
+  try(result.df$latestAnnualEstMileage <- (result.df$dist_diff/as.numeric(result.df$test_diff))*365.24, silent = TRUE)
+  try(result.df$EstimatePeriod <- result.df$test_diff/365.24, silent = TRUE)
+  try(result.df$EstimatePeriod[is.na(result.df$latestAnnualEstMileage)] <- NA, silent = TRUE)
 
   # Remove unwanted columns
-  result.df$test_diff = NULL
-  result.df$dist_diff = NULL
-  result.df$dvlaId = NULL
-  result.df$vehicleId = NULL
+  try(result.df$test_diff <- NULL, silent = TRUE)
+  try(result.df$dist_diff <- NULL, silent = TRUE)
+  try(result.df$dvlaId <- NULL, silent = TRUE)
+  try(result.df$vehicleId <- NULL, silent = TRUE)
 
   return(result.df)
 }

--- a/R/ulez.R
+++ b/R/ulez.R
@@ -27,6 +27,7 @@ get_ULEZ = function(vrm) {
     if (grepl('[^[:alnum:]]', vrm[i])) stop("VRMs must be alphanumeric.  Check VRM number ", i, " in your list (", vrm[i], ").")
   }
   message("This script only does 50 vrms per minute at most")
+  message("Warning: TfL ULEZ API is producing some strange results currently")
 
   # Create an empty list for results
   result.list = list()

--- a/man/get_ULEZ.Rd
+++ b/man/get_ULEZ.Rd
@@ -14,10 +14,10 @@ Download DVLA-based vehicle data from the TfL API using VRM.
 }
 \section{Details}{
 
-This function takes a a character vector of vehicle registrations (VRMs) and returns DVLA-based vehicle data from TfL's API, included ULEZ eligibility.
+This function takes a character vector of vehicle registrations (VRMs) and returns DVLA-based vehicle data from TfL's API, included ULEZ eligibility.
 It returns a data frame of those VRMs which were successfully used with the TfL API.  Vehicles are either compliant, non-compliant or exempt.  ULEZ-exempt vehicles will not have all vehicle details returned - they will simply be marked "exempt".
 
-Be aware that the API has usage limits.  The function will therefore limit API calls to 50 per minute.
+Be aware that the API has usage limits.  The function will therefore limit API calls to below 50 per minute - this is the maximum rate before an API key is required.
 }
 
 \examples{


### PR DESCRIPTION
Added message to get_ULEZ to make clear the TfL API is producing out-of-date/missing/false information.

Fixed get_MOT code to allow for a list of VRMs that entirely pre-MOT age.