### PR TITLE
A few fixes for some issues

### DIFF
--- a/R/dl.R
+++ b/R/dl.R
@@ -45,23 +45,26 @@ dl_stats19 = function(year = NULL,
                        ask = FALSE,
                        silent = FALSE,
                        timeout = 600) {
+
+  # download what the user wanted
   current_timeout = getOption("timeout")
   if (current_timeout < timeout) {
     options(timeout = timeout)
     on.exit(options(timeout = current_timeout))
   }
+  ## generate file name if one is not specified
   if (is.null(file_name)) {
     fnames = find_file_name(years = year, type = type)
     nfiles_found = length(fnames)
+    ## test for multliple files
     many_found = nfiles_found > 1
+    ## decide which one to import, as the escooters file seems to be unique for 2020 it defaults to the file names that matches 2017-2022
     if (many_found) {
-      if (interactive()) {
+      if (isTRUE(ask)) {
         fnames = select_file(fnames)
       } else {
-        if (isFALSE(silent)) {
-          message("More than one file found, selecting the first.")
-        }
-        fnames = fnames[1]
+        message(paste0("More than one file found, selecting ", fnames[2], " ignoring ", fnames[-2]))
+        fnames = fnames[2]
       }
     }
     zip_url = get_url(fnames)
@@ -96,11 +99,11 @@ dl_stats19 = function(year = NULL,
         resp = ""
       }
       if (resp != "" &
-        !grepl(
-          pattern = "yes|y",
-          x = resp,
-          ignore.case = TRUE
-        )) {
+          !grepl(
+            pattern = "yes|y",
+            x = resp,
+            ignore.case = TRUE
+          )) {
         stop("Stopping as requested", call. = FALSE)
       }
     }
@@ -114,6 +117,8 @@ dl_stats19 = function(year = NULL,
     if (isFALSE(silent)) {
       message("Data saved at ", destfile)
     }
-    return(NULL)
+
   }
+
+  return(destfile)
 }

--- a/R/get.R
+++ b/R/get.R
@@ -36,10 +36,8 @@
 #' @examples
 #' \donttest{
 #' if(curl::has_internet()) {
-#' col = get_stats19(year = 2022, type = "collision")
-#' cas2 = get_stats19(year = 2022, type = "casualty")
-#' veh = get_stats19(year = 2022, type = "vehicle")
-#' class(col)
+#' x = get_stats19(2022, silent = TRUE, format = TRUE)
+#' class(x)
 #' # data.frame output
 #' x = get_stats19(2022, silent = TRUE, output_format = "data.frame")
 #' class(x)
@@ -90,6 +88,7 @@
 #' }
 #' }
 #' }
+
 get_stats19 = function(year = NULL,
                       type = "collision",
                       data_dir = get_data_directory(),
@@ -99,9 +98,9 @@ get_stats19 = function(year = NULL,
                       silent = FALSE,
                       output_format = "tibble",
                       ...) {
-  # Set type to "collision" if it's "accident" or similar:
-  if (grepl("acc", x = type, ignore.case = TRUE)) {
-    type = "collision"
+
+  if(!exists("type")) {
+    stop("Type is required", call. = FALSE)
   }
   if (!output_format %in% c("tibble", "data.frame", "sf", "ppp")) {
     warning(
@@ -125,31 +124,37 @@ get_stats19 = function(year = NULL,
   }
 
   # download what the user wanted
-  dl_stats19(year = year,
+  # this is saved in the directory defined by data_dir
+  file_path <- dl_stats19(year = year,
              type = type,
              data_dir = data_dir,
              file_name = file_name,
              ask = ask,
              silent = silent)
+
+  ## read in file
+  ve = read_ve_ca(path = file_path)
+  ## read in set to NULL
   read_in = NULL
-  # read in
-  if(grepl("veh", x = type, ignore.case = TRUE)){
-    read_in = read_vehicles(
-      year = year,
-      data_dir = data_dir,
-      format = format)
-  } else if(grepl("cas", x = type, ignore.case = TRUE)) {
-    read_in = read_casualties(
-      year = year,
-      data_dir = data_dir,
-      format = format)
+  # read in from the file path defined above
+  if(grepl(type, "vehicles",  ignore.case = TRUE)){
+    if(format) {
+      read_in = format_vehicles(ve)
+    } else {
+      read_in = ve
+    }
+  } else if(grepl(type, "casualty", ignore.case = TRUE)) {
+    if(format) {
+      read_in = format_casualties(ve)
+    } else {
+      read_in = ve
+    }
   } else { # inline with type = "collision" by default
-    read_in = read_collisions(
-      year = year,
-      data_dir = data_dir,
-      format = format,
-      silent = silent)
-  }
+    if(format) {
+      read_in = format_collisions(ve)
+    } else {
+      read_in = ve
+    }
 
   # transform read_in into the desired format
   if (output_format != "tibble") {
@@ -162,5 +167,6 @@ get_stats19 = function(year = NULL,
   }
 
   read_in
-}
+  }
 
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,7 +16,7 @@
 get_url = function(file_name = "",
                    domain = "https://data.dft.gov.uk",
                    directory = "road-accidents-safety-data"
-                   ) {
+) {
   path = file.path(domain, directory, file_name)
   path
 }
@@ -43,11 +43,12 @@ current_year = function() as.integer(format(format(Sys.Date(), "%Y")))
 find_file_name = function(years = NULL, type = NULL) {
   result = unlist(stats19::file_names, use.names = FALSE)
   if(!is.null(years)) {
-    if(min(years) >= 2016) {
-      result = result[!grepl(pattern = "1979", x = result)]
+    if(min(years) >= 2018) {
+      result = result[grepl(pattern = years, x = result)]
     }
+    if(min(years) <= 2017) {
     result = result[!grepl(pattern = "adjust", x = result)]
-    result = result[grepl(pattern = years, x = result)]
+    result = result[grepl(pattern = "1979", x = result)]
     }
 
   # see https://github.com/ITSLeeds/stats19/issues/21
@@ -69,6 +70,7 @@ find_file_name = function(years = NULL, type = NULL) {
     message("No files found. Check the stats19 website on data.gov.uk")
   }
   unique(result)
+  }
 }
 
 #' Locate a file on disk
@@ -97,11 +99,12 @@ locate_files = function(data_dir = get_data_directory(),
   file_names = tools::file_path_sans_ext(file_names)
   dir_files = list.dirs(data_dir)
   # check is any file names match those on disk
-  files_on_disk = vapply(file_names, function(i) any(grepl(i, dir_files)),
-                logical(1))
-  if(any(files_on_disk)) { # return those on disk which match file names
-    files_on_disk = names(files_on_disk[files_on_disk])
-  }
+  files_on_disk <- list.files(dir_files, pattern = file_names, full.names = TRUE)
+  # files_on_disk = vapply(file_names, function(i) any(grepl(i, dir_files)),
+  #               logical(1))
+  # if(any(files_on_disk)) { # return those on disk which match file names
+  #   files_on_disk = names(files_on_disk[files_on_disk])
+  # }
   return(files_on_disk)
 }
 
@@ -152,6 +155,7 @@ locate_one_file = function(filename = NULL,
     return("More than one csv file found.")
   return(res)
 }
+
 utils::globalVariables(
   c("stats19_variables", "stats19_schema", "skip", "accidents_sample",
     "accidents_sample_raw", "casualties_sample", "casualties_sample_raw",
@@ -181,17 +185,6 @@ select_file = function(fnames) {
   message("Multiple matches. Which do you want to download?")
   selection = utils::menu(choices = fnames)
   fnames[selection]
-}
-
-#' Get data download dir
-#' @examples
-#' # get_data_directory()
-get_data_directory = function() {
-  data_directory = Sys.getenv("STATS19_DOWNLOAD_DIRECTORY")
-  if(data_directory != "") {
-    return(data_directory)
-  }
-  tempdir()
 }
 
 #' Set data download dir


### PR DESCRIPTION
swapped interactive with ask (which was not used) which is v important to be able to leave code running without being prompted.

Changed default file to second. The only year where two csvs are available is 2020 and for escooter data. Maybe this is interesting for some, but the other file should be the default.

returning destfile works better for dependent functions

get.R

main change is to skip the read_ functions which involve multiple nested functions appear to be unneccesary and are a headache to debug.

utils.R

Main change is to fix find_file_name function which was looking for a csv with year name for years before 2018. This data is all in one file which has 1979 in.